### PR TITLE
Stackage Fix

### DIFF
--- a/src/Crypto/TripleSec/Class.hs
+++ b/src/Crypto/TripleSec/Class.hs
@@ -10,6 +10,7 @@ module Crypto.TripleSec.Class where
 
 import           Data.Maybe
 import           Data.Monoid ((<>))
+import           GHC.Base
 
 import           Control.Monad.Except
 import           Crypto.Random

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-13.26
+resolver: lts-22.3
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 499889
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/13/26.yaml
-    sha256: ecb02ee16829df8d7219e7d7fe6c310819820bf335b0b9534bce84d3ea896684
-  original: lts-13.26
+    sha256: 53a2800f7fe0c4628af0e7d5e985707dd3af9863ac3983a43c835dbaa8ed5f35
+    size: 714094
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/3.yaml
+  original: lts-22.3


### PR DESCRIPTION
TripleSec has been omitted from Stackage as of lts-22.3. This makes it compatible with Stackage again.